### PR TITLE
Change sample target version to latest version (.NET 9)

### DIFF
--- a/TreeViewMaui/TreeViewMaui/App.xaml.cs
+++ b/TreeViewMaui/TreeViewMaui/App.xaml.cs
@@ -5,8 +5,11 @@
         public App()
         {
             InitializeComponent();
+        }
 
-            MainPage = new MainPage();
+        protected override Window CreateWindow(IActivationState? activationState)
+        {
+            return new Window(new MainPage());
         }
     }
 }

--- a/TreeViewMaui/TreeViewMaui/TreeViewMaui.csproj
+++ b/TreeViewMaui/TreeViewMaui/TreeViewMaui.csproj
@@ -57,8 +57,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="*" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="*" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="*" />
 		<PackageReference Include="Syncfusion.Maui.TreeView" Version="*" />
 	</ItemGroup>

--- a/TreeViewMaui/TreeViewMaui/TreeViewMaui.csproj
+++ b/TreeViewMaui/TreeViewMaui/TreeViewMaui.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 
@@ -57,9 +57,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="*" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="*" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="*" />
 		<PackageReference Include="Syncfusion.Maui.TreeView" Version="*" />
 	</ItemGroup>
 


### PR DESCRIPTION
Change sample target version to latest version (.NET 9)
Task ID : [Task 952717](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/952717): Migrate net6, net7and net8 samples to latest version